### PR TITLE
add file icon to .wasp file

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,11 @@
         "extensions": [
           ".wasp"
         ],
-        "configuration": "./language-configuration.json"
+        "configuration": "./language-configuration.json",
+        "icon": {
+          "dark": "./images/wasp-logo.png",
+          "light": "./images/wasp-logo.png"
+        }
       }
     ],
     "grammars": [


### PR DESCRIPTION
fixes #3

this feature is only available in insiders version as of now. Tested in VSCode v1.64.0-insider

![Screenshot](https://user-images.githubusercontent.com/33688622/151534660-ae6e4c3a-7060-4ce7-bc9a-f171fdeba64c.png)

