### PR TITLE
Add LSP server support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 *.vsix
 syntaxes/wasp.tmLanguage.json
+out

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,12 +6,20 @@
 	"version": "0.2.0",
     "configurations": [
         {
-            "name": "Extension",
             "type": "extensionHost",
             "request": "launch",
+            "name": "Launch Client",
+            "runtimeExecutable": "${execPath}",
             "args": [
-                "--extensionDevelopmentPath=${workspaceFolder}"
-            ]
+                "--extensionDevelopmentPath=${workspaceRoot}"
+            ],
+            "outFiles": [
+                "${workspaceRoot}/out/**/*.js"
+            ],
+            "preLaunchTask": {
+                "type": "npm",
+                "script": "watch"
+            }
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,22 @@ This is a Visual Studio Code language extension for [wasp](https://wasp-lang.dev
 
 ## Features
 
-For now, only feature is syntax highlighting of .wasp files.
+Features:
+- Syntax highlighting for `.wasp` files
+- Snippets for `.wasp` files
+- Wasp language server
+
+### Using the Wasp language server
+
+`waspls` (the Wasp language server) is very early in development and is not
+bundled with this extension or available for binary download. To set it up now:
+
+1. Clone https://github.com/wasp-lang/wasp
+2. Navigate to `waspls` directory
+3. Run `cabal build` (requires Haskell toolchain to be installed)
+4. Open vscode with this extension enabled, find the `Vscode-wasp: Executable`
+   setting, and enter the path to the binary created in step 3.
+5. Reload vscode.
 
 ## Development (for contributors)
 ### Resources
@@ -15,7 +30,7 @@ For now, only feature is syntax highlighting of .wasp files.
 ### Workflow
 Grammar is defined in `syntaxes/wasp.tmLanguage.yaml`, and you do most of the changes there.
 
-VSCode needs .json, not .yaml -> use `npm run build` to generate .json from .yaml.
+VSCode needs .json, not .yaml -> use `npm run compile-yaml` to generate .json from .yaml.
 
 `package.json` is also important -> besides general settings, we also define embedded languages and extension dependencies there.
 
@@ -30,6 +45,13 @@ VSCode needs .json, not .yaml -> use `npm run build` to generate .json from .yam
    how it got clasified/scoped by extension -> this is great for figuring out if extension does what it should do,
    which is at the end, applying correct scopes.
 7. Repeat step 4.
+
+For features implemented in typescript, the entry point for the project is `src/extension.ts`.
+Use `npm run compile-ts` to compile the typescript code, or `npm run watch` to 
+automatically recompile on changes.
+
+Use `npm run compile` to compile typescript code and convert the TextMate grammar
+to JSON.
 
 ### Publish
 Make sure you have `vsce` installed: `npm -g install vsce`.

--- a/language-configuration.json
+++ b/language-configuration.json
@@ -17,7 +17,9 @@
         ["[", "]"],
         ["(", ")"],
         ["\"", "\""],
-        ["'", "'"]
+        ["'", "'"],
+        ["{=psl", "psl=}"],
+        ["{=json", "json=}"]
     ],
     // symbols that can be used to surround a selection
     "surroundingPairs": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,30 @@
     "": {
       "name": "wasp",
       "version": "0.0.5",
+      "dependencies": {
+        "vscode-languageclient": "^8.0.1"
+      },
       "devDependencies": {
-        "js-yaml": "^3.14.0"
+        "@types/node": "^17.0.37",
+        "@types/vscode": "^1.67.0",
+        "js-yaml": "^3.14.0",
+        "typescript": "^4.7.2"
       },
       "engines": {
         "vscode": "^1.42.0"
       }
+    },
+    "node_modules/@types/node": {
+      "version": "17.0.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.37.tgz",
+      "integrity": "sha512-22CDt5mU+EbwJ/JYw4pZGVtO0M0UhaFQP1pJ+JW+lQYx8cqErY//QfvpE0nVBr4LJpPcIrFs1Ew2LAIx1OSXZw==",
+      "dev": true
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
+      "integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
+      "dev": true
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -22,6 +40,25 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/esprima": {
       "version": "4.0.1",
@@ -49,14 +86,115 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "node_modules/typescript": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
+      "integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ==",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageclient": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz",
+      "integrity": "sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==",
+      "dependencies": {
+        "minimatch": "^3.0.4",
+        "semver": "^7.3.5",
+        "vscode-languageserver-protocol": "3.17.1"
+      },
+      "engines": {
+        "vscode": "^1.67.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
+      "integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
+      "dependencies": {
+        "vscode-jsonrpc": "8.0.1",
+        "vscode-languageserver-types": "3.17.1"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
+      "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   },
   "dependencies": {
+    "@types/node": {
+      "version": "17.0.37",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.37.tgz",
+      "integrity": "sha512-22CDt5mU+EbwJ/JYw4pZGVtO0M0UhaFQP1pJ+JW+lQYx8cqErY//QfvpE0nVBr4LJpPcIrFs1Ew2LAIx1OSXZw==",
+      "dev": true
+    },
+    "@types/vscode": {
+      "version": "1.67.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.67.0.tgz",
+      "integrity": "sha512-GH8BDf8cw9AC9080uneJfulhSa7KHSMI2s/CyKePXoGNos9J486w2V4YKoeNUqIEkW4hKoEAWp6/cXTwyGj47g==",
+      "dev": true
+    },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -65,6 +203,25 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "esprima": {
       "version": "4.0.1",
@@ -82,11 +239,75 @@
         "esprima": "^4.0.0"
       }
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "typescript": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
+      "integrity": "sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==",
+      "dev": true
+    },
+    "vscode-jsonrpc": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.0.1.tgz",
+      "integrity": "sha512-N/WKvghIajmEvXpatSzvTvOIz61ZSmOSa4BRA4pTLi+1+jozquQKP/MkaylP9iB68k73Oua1feLQvH3xQuigiQ=="
+    },
+    "vscode-languageclient": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.0.1.tgz",
+      "integrity": "sha512-9XoE+HJfaWvu7Y75H3VmLo5WLCtsbxEgEhrLPqwt7eyoR49lUIyyrjb98Yfa50JCMqF2cePJAEVI6oe2o1sIhw==",
+      "requires": {
+        "minimatch": "^3.0.4",
+        "semver": "^7.3.5",
+        "vscode-languageserver-protocol": "3.17.1"
+      }
+    },
+    "vscode-languageserver-protocol": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.1.tgz",
+      "integrity": "sha512-BNlAYgQoYwlSgDLJhSG+DeA8G1JyECqRzM2YO6tMmMji3Ad9Mw6AW7vnZMti90qlAKb0LqAlJfSVGEdqMMNzKg==",
+      "requires": {
+        "vscode-jsonrpc": "8.0.1",
+        "vscode-languageserver-types": "3.17.1"
+      }
+    },
+    "vscode-languageserver-types": {
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.1.tgz",
+      "integrity": "sha512-K3HqVRPElLZVVPtMeKlsyL9aK0GxGQpvtAUTfX4k7+iJ4mc1M+JM+zQwkgGy2LzY0f0IAafe8MKqIkJrxfGGjQ=="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,39 +1,92 @@
 {
-    "name": "wasp",
-    "version": "0.0.1",
-    "lockfileVersion": 1,
-    "requires": true,
-    "dependencies": {
-        "argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "dev": true,
-            "requires": {
-                "sprintf-js": "~1.0.2"
-            }
-        },
-        "esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "dev": true
-        },
-        "js-yaml": {
-            "version": "3.14.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-            "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-            "dev": true,
-            "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            }
-        },
-        "sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
-        }
+  "name": "wasp",
+  "version": "0.0.5",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wasp",
+      "version": "0.0.5",
+      "devDependencies": {
+        "js-yaml": "^3.14.0"
+      },
+      "engines": {
+        "vscode": "^1.42.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     }
+  },
+  "dependencies": {
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -59,16 +59,16 @@
       "type": "object",
       "title": "Wasp",
       "properties": {
-        "wasp.server.maxNumberOfProblems": {
-          "scope": "resource",
-          "type": "number",
-          "default": 100,
-          "description": "Controls the maximum number of problems produced by the server."
-        },
         "wasp.server.executable": {
           "scope": "resource",
           "type": "string",
-          "description": "Path to wasp language server executable. Uses bundled waspls if not set."
+          "description": "Path to wasp language server executable. Tries to use waspls on PATH if not set."
+        },
+        "wasp.server.useOutputPanelForLogging": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "description": "Send logs from the wasp language server to the output panel. If enabled, the log file setting will be ignored"
         },
         "wasp.server.logFile": {
           "scope": "resource",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,12 @@
         }
       }
     ],
+    "snippets": [
+      {
+        "language": "wasp",
+        "path": "./snippets/wasp.json"
+      }
+    ],
     "grammars": [
       {
         "language": "wasp",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
           "scope": "resource",
           "type": "boolean",
           "default": true,
-          "description": "Send logs from the wasp language server to the output panel. If enabled, the log file setting will be ignored"
+          "description": "Send logs from the wasp language server to the output panel. If enabled, the log file setting will be ignored."
         },
         "wasp.server.logFile": {
           "scope": "resource",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
   "categories": [
     "Programming Languages"
   ],
+  "activationEvents": [
+    "onCommand:vscode-wasp.restartLanguageServer",
+    "onLanguage:wasp"
+  ],
+  "main": "./out/extension",
   "contributes": {
     "languages": [
       {
@@ -49,14 +54,53 @@
           "meta.embedded.block.prisma": "prisma"
         }
       }
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Wasp",
+      "properties": {
+        "wasp.server.maxNumberOfProblems": {
+          "scope": "resource",
+          "type": "number",
+          "default": 100,
+          "description": "Controls the maximum number of problems produced by the server."
+        },
+        "wasp.server.executable": {
+          "scope": "resource",
+          "type": "string",
+          "description": "Path to wasp language server executable. Uses bundled waspls if not set."
+        },
+        "wasp.server.logFile": {
+          "scope": "resource",
+          "type": "string",
+          "description": "Path to log file for wasp language server. No logging if not set."
+        }
+      }
+    },
+    "commands": [
+      {
+        "command": "vscode-wasp.restartLanguageServer",
+        "title": "Wasp: Restart Wasp LSP Server"
+      }
     ]
   },
   "devDependencies": {
-    "js-yaml": "^3.14.0"
+    "@types/node": "^17.0.37",
+    "@types/vscode": "^1.67.0",
+    "js-yaml": "^3.14.0",
+    "typescript": "^4.7.2"
   },
   "scripts": {
-    "build": "js-yaml syntaxes/wasp.tmLanguage.yaml > syntaxes/wasp.tmLanguage.json",
-    "vscode:prepublish": "npm run build"
+    "compile-ts": "tsc -b",
+    "watch": "tsc -b -w",
+    "compile-yaml": "js-yaml syntaxes/wasp.tmLanguage.yaml > syntaxes/wasp.tmLanguage.json",
+    "compile": "npm run compile-ts && npm run compile-yaml",
+    "vscode:prepublish": "npm run compile"
   },
-  "extensionDependencies": ["Prisma.prisma"]
+  "extensionDependencies": [
+    "Prisma.prisma"
+  ],
+  "dependencies": {
+    "vscode-languageclient": "^8.0.1"
+  }
 }

--- a/snippets/wasp.json
+++ b/snippets/wasp.json
@@ -1,0 +1,41 @@
+{
+  "Page": {
+    "prefix": "page",
+    "description": "Create a new page and matching",
+    "body": [
+      "route ${1:Name}Route { path: \"/${2:path}\", to: ${1:Name} }",
+      "page ${1:Name} {",
+      "\tcomponent: import ${1:name} from \"@ext/${3:component}\"",
+      "}"
+    ]
+  },
+
+  "Query": {
+    "prefix": "query",
+    "body": [
+      "query ${1:name} {",
+      "\tfn: import ${2:function} from \"@ext/${3:sourceFile}\",",
+      "\tentities: [${4:Entities}]",
+      "}"
+    ]
+  },
+
+  "Action": {
+    "prefix": "action",
+    "body": [
+      "action ${1:name} {",
+      "\tfn: import ${2:function} from \"@ext/${3:sourceFile}\",",
+      "\tentities: [${4:Entities}]",
+      "}"
+    ]
+  },
+
+  "Entity": {
+    "prefix": "entity",
+    "body": [
+      "entity ${1:Name} {=psl",
+      "\t${2:schema}",
+      "psl=}"
+    ]
+  }
+}

--- a/snippets/wasp.json
+++ b/snippets/wasp.json
@@ -1,7 +1,7 @@
 {
   "Page": {
     "prefix": "page",
-    "description": "Create a new page and matching",
+    "description": "Create a new page and route",
     "body": [
       "route ${1:Name}Route { path: \"/${2:path}\", to: ${1:Name} }",
       "page ${1:Name} {",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -57,7 +57,10 @@ export async function activate(context: ExtensionContext) {
     }
   }
 
-  const logFile = config.server.logFile;
+  // TODO: send these settings to waspls so it can update its logging output if
+  // these are changed while the language server is running
+  const useOutputPanel = config.server.useOutputPanelForLogging;
+  const logFile = useOutputPanel ? "[OUTPUT]" : config.server.logFile;
   const logFileOpt = logFile.trim() === '' ? [] : ['--log=' + logFile];
 
   let runArgs = [...logFileOpt];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,135 @@
+import * as os from 'os';
+import { workspace, ExtensionContext, window, commands } from 'vscode';
+
+import {
+  LanguageClient,
+  LanguageClientOptions,
+  ServerOptions,
+  TransportKind
+} from 'vscode-languageclient/node';
+import { promisify } from 'util';
+import { execFile } from 'child_process';
+
+let client: LanguageClient;
+
+const outputChannel = window.createOutputChannel('Wasp Language Server');
+
+export async function activate(context: ExtensionContext) {
+  console.log('..Extension "vscode-wasp" is now active..');
+
+  const config = workspace.getConfiguration('wasp');
+
+  const userDefinedExecutablePath = config.server.executable;
+  let executablePath = userDefinedExecutablePath === '' ? 'waspls' : userDefinedExecutablePath;
+
+  console.log(`Trying to find the server executable in ${executablePath}`);
+  executablePath = executablePath
+    .replace('${HOME}', os.homedir)
+    .replace('${home}', os.homedir)
+    .replace(/^~/, os.homedir);
+  if (executablePath === '') {
+    window.showErrorMessage(`wasp executable path ${executablePath} is empty, check your configuration`);
+    return;
+  }
+
+  let folders = workspace.workspaceFolders
+  if (folders) {
+    let folder = folders[0]
+    if (folder) {
+      executablePath = executablePath.replace('${workspaceFolder}', folder.uri.path).replace('${workspaceRoot}', folder.uri.path);
+    }
+  }
+
+  console.log(`Location after path variables subsitution: ${executablePath}`);
+
+  const executableStatus = await checkExecutable(executablePath);
+
+  if (executableStatus !== 'available') {
+    if (executableStatus === 'timedout') {
+      window.showInformationMessage(`The wasp server process has timed out.`);
+    } else {
+      if (userDefinedExecutablePath === '') {
+        window.showErrorMessage('No `waspls` executable is available in the VSCode PATH.');
+        return;
+      } else {
+        window.showInformationMessage(`The user defined executable path couldn't be run: [${executablePath}].`);
+      }
+    }
+  }
+
+  const logFile = config.server.logFile;
+  const logFileOpt = logFile.trim() === '' ? [] : ['--log=' + logFile];
+
+  let runArgs = [...logFileOpt];
+  let debugArgs = [...logFileOpt];
+
+  let serverOptions: ServerOptions = {
+    run: {
+      command: executablePath,
+      transport: TransportKind.stdio,
+      args: runArgs,
+    },
+    debug: {
+      command: executablePath,
+      transport: TransportKind.stdio,
+      args: debugArgs,
+    }
+  };
+
+  let clientOptions: LanguageClientOptions = {
+    documentSelector: [{ scheme: 'file', language: 'wasp' }],
+    initializationOptions: {
+      'vscode-wasp': workspace.getConfiguration('vscode-wasp'),
+    },
+    outputChannel: outputChannel
+  };
+
+  client = new LanguageClient(
+    'vscode-wasp',
+    'VSCode Wasp',
+    serverOptions,
+    clientOptions,
+  );
+
+  client.start();
+  outputChannel.appendLine('..Wasp LSP Server has been started..');
+
+  context.subscriptions.push(commands.registerCommand('vscode-wasp.restartLanguageServer', async () => {
+    if (client) {
+      try {
+        console.log(`..Restarting Wasp LSP Server..`);
+        await client.restart();
+        console.log(`..Wasp LSP Server has been restarted..`);
+      } catch (err) {
+        outputChannel.appendLine(`Couldn't restart Wasp LSP Server: ${err.message}`);
+      }
+    }
+  }));
+}
+
+export function deactivate() {
+  if (client) {
+    client.stop();
+  }
+}
+
+async function checkExecutable(executablePath: string): Promise<Status> {
+  const execPromise = promisify(execFile)
+    (executablePath, ['version'], { timeout: 2000, windowsHide: true })
+    .then(() => Status.Available).catch(_err => Status.Missing);
+
+  const timeoutPromise = new Promise<Status>((resolve, _reject) => {
+    let timer = setTimeout(() => {
+      clearTimeout(timer);
+      resolve(Status.Timedout);
+    }, 1000);
+  });
+
+  return Promise.race([execPromise, timeoutPromise]);
+}
+
+enum Status {
+  Available = 'available',
+  Missing = 'missing',
+  Timedout = 'timedout',
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ const outputChannel = window.createOutputChannel('Wasp Language Server');
 export async function activate(context: ExtensionContext) {
   console.log('..Extension "vscode-wasp" is now active..');
 
+  // Configuration name and properties are set in package.json
   const config = workspace.getConfiguration('wasp');
 
   const { executablePath, usePathWaspls } = resolveExecutablePath(config.server.executable);
@@ -108,7 +109,9 @@ function resolveExecutablePath(userDefinedExecutablePath: string): { executableP
 
   let executablePath = userDefinedExecutablePath;
 
-  // Substitute vscode path variables into configuration
+  // Interpolate in values for common vscode path variables
+
+  // Path variable for home directory
   console.log(`Trying to find the server executable in ${executablePath}`);
   executablePath = executablePath
     .replace('${HOME}', os.homedir)
@@ -119,6 +122,7 @@ function resolveExecutablePath(userDefinedExecutablePath: string): { executableP
     return;
   }
 
+  // Path variable for workspace folder
   let folders = workspace.workspaceFolders;
   if (folders) {
     let folder = folders[0];

--- a/syntaxes/wasp.tmLanguage.yaml
+++ b/syntaxes/wasp.tmLanguage.yaml
@@ -23,7 +23,7 @@ repository:
 
   declVariable:
     patterns:
-      - name: variable.other.wasp
+      - name: entity.name.class.wasp
         match: "[a-zA-Z][0-9a-zA-Z]*"
 
   variable:

--- a/syntaxes/wasp.tmLanguage.yaml
+++ b/syntaxes/wasp.tmLanguage.yaml
@@ -1,47 +1,129 @@
----
-# NOTE: Check README for instructions and advice.
-# TODO: This grammar is a very simple, quick and dirty solution and it will not work in 100% cases.
-#   Due to how quickly is Wasp changing, it makes sense to keep it light, not 100% precise for now,
-#   and fix it as we go, and in the future we can look into more permanent options: 
-#   either investing much more time into it and making it 100%,
-#   or dropping it completely and switching directly to semantic analysis
-#   via external service -> meaning that we feed the content of file to Wasp parser and it returns
-#   tokens. If that can be made to work fast enough, that could be attractive solution,
-#   to avoid maintaing this grammar (such approach is called "semantic highlighting" in vs code docs).
-#   Ultimate solution would be to implement Wasp language server (LSP).
-#   
 "$schema": https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json
 name: wasp
 scopeName: source.wasp
 patterns:
-  # Order here is important!
-  - include: "#jsonClosure"
-  - include: "#prismaClosure"
   - include: "#comment"
-  - include: "#strings"
-  - include: "#wson"
-  - include: "#types"
+  - include: "#type"
+  - include: "#declVariable"
+  - include: "#value"
+
 repository:
   comment:
-    name: comment.line.wasp
-    match: "//.*$"
-  strings:
+    patterns:
+      - name: comment.line.wasp
+        match: "//.*$"
+      - name: comment.block.wasp
+        begin: "/\\*"
+        end: "\\*/"
+  
+  type:
+    patterns:
+      - name: storage.type.wasp # Declaration types
+        match: "\\b(action|app|entity|job|page|query|route)"
+
+  declVariable:
+    patterns:
+      - name: variable.other.wasp
+        match: "[a-zA-Z][0-9a-zA-Z]*"
+
+  variable:
+    patterns:
+      - name: variable.other.wasp
+        match: "[a-zA-Z][0-9a-zA-Z]*"
+
+  value:
+    patterns:
+      - include: "#string"
+      - include: "#number"
+      - include: "#constant"
+      - include: "#jsImport"
+      - include: "#prismaClosure"
+      - include: "#jsonClosure"
+      - include: "#array"
+      - include: "#dict"
+      - include: "#variable"
+
+  string:
     name: string.quoted.double.wasp
     begin: "\""
     end: "\""
     patterns:
-      - name: constant.character.escape.wasp
-        match: "\\\\."
-  types:
+      - include: "#stringcontent"
+  
+  number:
+    name: constant.numeric.wasp
+    match: "-?\\d+(\\.\\d+)?"
+
+  constant:
     patterns:
-      - name: support.type.wasp
-        match: "\\b(app|route|page|entityPSL|query|action|dependencies)\\b"
+    - comment: Booleans
+      name: constant.language.boolean.wasp
+      match: "\\b(true|false)"
+    - comment: Enum values
+      name: constant.language.enum.wasp
+      match: "\\b(EmailAndPassword|PostgreSQL|SQLite|Simple|PgBoss)"
+    
+  # From https://github.com/textmate/javascript.tmbundle/blob/master/Syntaxes/JavaScript.plist#L49
+  # Explanatory comments added by Wasp Team
+  jsImport:
+    # starts word "import" without any character before it and no colon after it
+    begin: "(?<!\\.)\\b(import)(?!\\s*:)\\b"
+    beginCaptures:
+      1:
+        name: keyword.control.jsImport.wasp
+    # ends after a string (double quotes with stuff between them)
+    end: "(?<=\".*\")"
+    # no end captures
+    name: meta.jsImport.wasp
+    patterns:
+      - comment:
+          import { getList } from "@ext/queries.js"
+          ^^^^^^
+        match: "import"
+        name: keyword.control.import.wasp
+      - comment: |-
+          import { getList } from "@ext/queries.js"
+                             ^^^^
+        match: "from"
+        name: keyword.control.from.wasp
+      - comment: |-
+          import { getList } from "@ext/queries.js"
+                                  ^^^^^^^^^^^^^^^^^
+        begin: "\""
+        end: "\""
+        name: string.quoted.double.wasp
+        patterns:
+          - include: "#stringcontent"
+          - comment: |-
+              import { getList } from "@ext/queries.js"
+                                       ^^^^
+            match: "@ext"
+            name: support.constant.shortpath.wasp
+      - comment: |-
+          import { getList } from "@ext/queries.js"
+                 ^^^^^^^^^^^
+        begin: "{"
+        beginCaptures:
+          0:
+            name: punctuation.definition.modules.begin.wasp
+        end: "}"
+        endCaptures:
+          0:
+            name: punctuation.definition.modules.end.wasp
+        contentName: variable.other.jsImport.module.wasp
+      - comment: |-
+          import MainPage from "@ext/MainPage.js"
+                 ^^^^^^^^
+        match: "\\b[a-zA-Z_][a-zA-Z_0-9]*\\b"
+        name: variable.other.jsImport.module.wasp
+
   jsonClosure:
     name: meta.embedded.block.json
     begin: "{=json"
     end: "json=}"
     patterns:
       - include: "source.json"
+
   # TODO: While it does higlight syntax to some part as prisma code,
   #   it does not do it completely, just some parts of it.
   #   Compare with schema.prisma file to see the difference.
@@ -55,35 +137,62 @@ repository:
     end: "psl=}"
     patterns:
       - include: "source.prisma"
-  wson:
-    name: meta.structure.dictionary.wasp
-    begin: "{"
-    beginCaptures: { 0: { name: punctuation.separator.dictionary.begin.wasp } }
-    end: "}"
-    endCaptures: { 0: { name: punctuation.separator.dictionary.end } }
+
+  array:
+    name: meta.structure.array.wasp
+    begin: "\\["
+    beginCaptures:
+      0:
+        name: punctuation.separator.array.begin.wasp
+    end: "\\]"
+    endCaptures:
+      0:
+        name: punctuation.separator.array.end.wasp
     patterns:
       - include: "#comment"
-      # wson key
-      # TODO: This is now very primitive approach that works in limited situations..
-      # It should be upgraded so that it uses this 'match' as 'begin', and then
-      # looks for , or } as 'end', and then also parses stuff in between recursively (via 'patterns'),
-      # meaning it could be another wson, or a primitive value or array or smth like that.
-      # Check how they do it here: https://github.com/microsoft/vscode-JSON.tmLanguage/blob/master/JSON.tmLanguage#L179 .
-      - match: "([a-zA-Z][0-9a-zA-Z]*)\\s*(:)"
-        captures:
-          1: { name: support.type.property-name.wasp }
-          2: { name: punctuation.separator.dictionary.key-value.wasp }
-      - include: "#jsImportStmt"
-      - include: "#strings"
-  # TODO: This is a very primitive implementation that works only for "happy" cases,
-  #   we should improve it, but the full one is pretty complex.
-  #   One example of where it could break right now is legal 'from' between 'import' and 'from',
-  #   e.g. import { from } from "foo/bar".
-  # There is an instance of full implementation here:
-  #   https://github.com/textmate/javascript.tmbundle/blob/master/Syntaxes/JavaScript.plist#L49
-  jsImportStmt:
-    begin: "\\bimport\\b"
-    beginCaptures: { 0: { name: keyword.control.jsimport.wasp } }
-    end: "\\bfrom\\b"
-    endCaptures: { 0: { name: keyword.control.jsfrom.wasp } }
-    name: meta.jsimport.wasp
+      - include: "#value"
+      - comment: Comma separators in an array
+        name: punctuation.separator.array.wasp
+        match: ","
+      - comment: Where a comma is a expected but something else was found
+        name: invalid.illegal.expected-array-separator.wasp
+        match: "[^\\s\\]]"
+
+  dict:
+    name: meta.structure.dictionary.wasp
+    begin: "{"
+    beginCaptures:
+      0:
+        name: punctuation.separator.dictionary.begin.wasp
+    end: "}"
+    endCaptures:
+      0:
+        name: punctuation.separator.dictionary.end.wasp
+    patterns:
+      - include: "#comment"
+      - include: "#dictKey"
+      - include: "#value"
+      - comment: Colons and commas in a dictionary
+        begin: ":"
+        beginCaptures:
+          0:
+            name: punctuation.separator.dictionary.key-value.wasp
+        end: "(,)|(?=\\})"
+        endCaptures:
+          1:
+            name: punctuation.separator.dictionary.pair.wasp
+        name: meta.structure.dictionary.value.wasp
+        patterns:
+          - include: "#value"
+          - comment: Something unexpected
+            name: invalid.illegal.expected-dictionary-separator.wasp
+            match: "[^\\s,]"
+  
+  dictKey:
+    name: meta.object-literal.key.wasp
+    match: "[a-zA-Z]+(?=:)"
+
+  stringcontent:
+    patterns:
+    - name: constant.character.escape.wasp
+      match: "\\\\."

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2020",
+    "lib": [
+      "es2020"
+    ],
+    "outDir": "out",
+    "rootDir": "src",
+    "sourceMap": true
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "node_modules"
+  ],
+}


### PR DESCRIPTION
Adds support for using [waspls](https://github.com/wasp-lang/wasp/tree/main/waspls) in the extension. The extension now looks in PATH for `waspls` (or uses the user configured path, if set in the extension settings) for the executable and runs it. The code that deals with this is in `src/extension.ts`.

This does not bundle `waspls`, so separate installation of the language server is still needed.

Also, it updates the textmate grammar to match the latest wasp language and adds code snippets for pages, queries, actions, and entities.