### PR TITLE
Adds fix for comments syntax highlight

### DIFF
--- a/syntaxes/wasp.tmLanguage.yaml
+++ b/syntaxes/wasp.tmLanguage.yaml
@@ -186,6 +186,7 @@ repository:
             name: punctuation.separator.dictionary.pair.wasp
         name: meta.structure.dictionary.value.wasp
         patterns:
+          - include: "#comment"
           - include: "#value"
           - comment: Something unexpected
             name: invalid.illegal.expected-dictionary-separator.wasp


### PR DESCRIPTION
Closes #8

The issue was the way our dict value pattern was written. It captured everything starting with `:` and ending with `{` or `,`.

This meant that the comment was never matched.

**Adding the possibility that a comment can show up after the dict key, the syntax highlighting works.** I don't think this is the cleanest, but it works and won't break anything else. 

<img width="608" alt="Screenshot 2023-10-27 at 16 17 53" src="https://github.com/wasp-lang/vscode-wasp/assets/2223680/de824392-c29c-43a8-9799-0ce062565e57">
<img width="926" alt="Screenshot 2023-10-27 at 16 17 51" src="https://github.com/wasp-lang/vscode-wasp/assets/2223680/6158511e-7a23-4bc8-a5be-ef805e2ca1e3">
<img width="595" alt="Screenshot 2023-10-27 at 16 17 49" src="https://github.com/wasp-lang/vscode-wasp/assets/2223680/d61f0c43-c88e-4413-b73f-1819eec7d586">
