### PR TITLE
Disable extension features for Wasp 0.24+

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     outputChannel.appendLine(
       `Wasp version is ${waspVersion} (>= ${firstWaspVersionWithoutLanguageServer}), which no longer uses the Wasp DSL. Skipping snippets and Wasp LSP Server.`,
     );
+    warnAboutWaspDslRemovalWhenWaspFileOpen(context, waspVersion);
     return;
   }
 
@@ -158,6 +159,30 @@ export function deactivate(): void {
   if (client) {
     client.stop();
   }
+}
+
+// Shows a one-time notification when a `.wasp` file is open (or gets opened)
+// while the installed Wasp version no longer uses the Wasp DSL (0.24+).
+function warnAboutWaspDslRemovalWhenWaspFileOpen(
+  context: ExtensionContext,
+  waspVersion: string,
+): void {
+  let warned = false;
+
+  const warnIfWaspFile = (document: { languageId: string }): void => {
+    if (warned || document.languageId !== "wasp") return;
+    warned = true;
+    window.showWarningMessage(
+      `This project uses Wasp ${waspVersion}, which no longer uses the Wasp DSL (\`.wasp\` files).` +
+        ` Wasp config now lives in TypeScript. This extension's \`.wasp\` features are disabled.`,
+    );
+  };
+
+  for (const document of workspace.textDocuments) {
+    warnIfWaspFile(document);
+  }
+
+  context.subscriptions.push(workspace.onDidOpenTextDocument(warnIfWaspFile));
 }
 
 // For a given user defined wasp executable path with possibly vs-code specific path variables,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,15 @@
+import { execFile } from "child_process";
 import * as os from "os";
+import { promisify } from "util";
 import {
-  languages,
-  workspace,
-  ExtensionContext,
-  window,
   commands,
   CompletionItem,
+  ExtensionContext,
+  languages,
   SnippetString,
+  TextEditor,
+  window,
+  workspace,
 } from "vscode";
 import {
   LanguageClient,
@@ -14,8 +17,6 @@ import {
   ServerOptions,
   TransportKind,
 } from "vscode-languageclient/node";
-import { promisify } from "util";
-import { execFile } from "child_process";
 
 let client: LanguageClient | null = null;
 
@@ -66,7 +67,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     outputChannel.appendLine(
       `Wasp version is ${waspVersion} (>= ${firstWaspVersionWithoutLanguageServer}), which no longer uses the Wasp DSL. Skipping snippets and Wasp LSP Server.`,
     );
-    warnAboutWaspDslRemovalWhenWaspFileOpen(context, waspVersion);
+    setupWarningWhenOpeningWaspDSLFile(context, waspVersion);
     return;
   }
 
@@ -161,28 +162,30 @@ export function deactivate(): void {
   }
 }
 
-// Shows a one-time notification when a `.wasp` file is open (or gets opened)
-// while the installed Wasp version no longer uses the Wasp DSL (0.24+).
-function warnAboutWaspDslRemovalWhenWaspFileOpen(
-  context: ExtensionContext,
-  waspVersion: string,
-): void {
+function setupWarningWhenOpeningWaspDSLFile(context: ExtensionContext, waspVersion: string): void {
   let warned = false;
 
-  const warnIfWaspFile = (document: { languageId: string }): void => {
-    if (warned || document.languageId !== "wasp") return;
-    warned = true;
-    window.showWarningMessage(
-      `This project uses Wasp ${waspVersion}, which no longer uses the Wasp DSL (\`.wasp\` files).` +
-        ` Wasp config now lives in TypeScript. This extension's \`.wasp\` features are disabled.`,
-    );
+  const warnIfWaspFileVisible = async (editors: readonly TextEditor[]): Promise<void> => {
+    if (!warned && editors.some((editor) => editor.document.languageId === "wasp")) {
+      warned = true;
+
+      const OPTIONS = ["Learn more", "OK"] as const;
+
+      const choice = await window.showWarningMessage(
+        `This project uses Wasp ${waspVersion}, which no longer supports the Wasp DSL (\`.wasp\` files).` +
+          ` Wasp config now lives in TypeScript. This extension's \`.wasp\` features are disabled.`,
+        {},
+        ...OPTIONS,
+      );
+
+      if (choice === "Learn more") {
+        await commands.executeCommand("vscode.open", "https://wasp.sh/docs/guides/legacy/wasp-dsl");
+      }
+    }
   };
 
-  for (const document of workspace.textDocuments) {
-    warnIfWaspFile(document);
-  }
-
-  context.subscriptions.push(workspace.onDidOpenTextDocument(warnIfWaspFile));
+  warnIfWaspFileVisible(window.visibleTextEditors);
+  context.subscriptions.push(window.onDidChangeVisibleTextEditors(warnIfWaspFileVisible));
 }
 
 // For a given user defined wasp executable path with possibly vs-code specific path variables,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,6 +59,16 @@ export async function activate(context: ExtensionContext): Promise<void> {
     return;
   }
 
+  // The Wasp DSL is removed in Wasp 0.24 onwards, so we disable related
+  // functionality (snippets and language server) from that version on.
+  const firstWaspVersionWithoutLanguageServer = "0.24.0";
+  if (compareSimpleSemvers(waspVersion, firstWaspVersionWithoutLanguageServer) !== -1) {
+    outputChannel.appendLine(
+      `Wasp version is ${waspVersion} (>= ${firstWaspVersionWithoutLanguageServer}), which no longer uses the Wasp DSL. Skipping snippets and Wasp LSP Server.`,
+    );
+    return;
+  }
+
   // Register snippets for .wasp files.
   const snippets = getSnippets(waspVersion);
   const provider = languages.registerCompletionItemProvider("wasp", {


### PR DESCRIPTION
## What

Wasp 0.24 removes the Wasp DSL, so the snippet completions and the `waspls` language server no longer apply.

This adds a version guard in `activate()` that, after detecting the installed wasp executable's version, skips registering snippets and starting the LSP server when the version is `0.24.0` or newer. A line is logged to the output channel explaining why.

Then, if/when a `.wasp` file is opened, we'll show a once-per-session warning saying that the current Wasp version does not support them.

## Behavior

- Wasp < 0.24: unchanged (snippets + language server).
- Wasp >= 0.24: snippets and language server are skipped, warning shown when opening `.wasp` file.


<img width="492" height="182" alt="file-35a44ae3f465c4628bba9e4e9f099902" src="https://github.com/user-attachments/assets/40923c94-6e44-401e-bbff-eafbc1d1ad79" />

<img width="337" height="165" alt="dyn-a9ce97871a8b707af2706b03b2e3fead" src="https://github.com/user-attachments/assets/14db671b-d1bc-4f72-a89d-bc266f72d528" />
